### PR TITLE
fix: convert transaction timestamps to dates in UTC

### DIFF
--- a/python/transtractor/structs/transaction.py
+++ b/python/transtractor/structs/transaction.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import date as Date
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 @dataclass
@@ -33,7 +33,9 @@ class Transaction:
         """
         if isinstance(date, int):
             # Convert milliseconds since epoch to date
-            self.date = datetime.fromtimestamp(date / 1000.0).date()
+            # Timestamps from the Rust core are midnight UTC; convert in UTC
+            # so the calendar date is identical in every local timezone.
+            self.date = datetime.fromtimestamp(date / 1000.0, tz=timezone.utc).date()
         else:
             self.date = date
         self.date_index = date_index

--- a/tests/python/test_structs__transaction.py
+++ b/tests/python/test_structs__transaction.py
@@ -1,0 +1,49 @@
+"""Tests for the Transaction struct."""
+
+import os
+import subprocess
+import sys
+from datetime import date as Date
+
+from transtractor.structs.transaction import Transaction
+
+
+def test_timestamp_converts_to_utc_date():
+    """Test that a millisecond timestamp is converted to a date in UTC."""
+    # 2025-01-01T00:00:00Z, as produced by the Rust core (midnight UTC)
+    transaction = Transaction(
+        date=1735689600000,
+        date_index=0,
+        description="Transaction 1",
+        amount=50000.0,
+        balance=100000.0,
+    )
+
+    assert transaction.date == Date(2025, 1, 1)
+
+
+def test_timestamp_conversion_is_timezone_independent():
+    """Test that the converted date does not depend on the local timezone.
+
+    Runs the conversion in subprocesses pinned to timezones west and east
+    of UTC, where a local-time interpretation of a midnight-UTC timestamp
+    would shift the calendar date by a day.
+    """
+    script = (
+        "from transtractor.structs.transaction import Transaction;"
+        "t = Transaction(1735689600000, 0, 'Transaction 1', 50000.0, 100000.0);"
+        "print(t.date.isoformat())"
+    )
+
+    for tz in ("America/New_York", "Australia/Sydney", "UTC"):
+        env = {**os.environ, "TZ": tz}
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "2025-01-01", (
+            f"Date shifted in timezone {tz}: got {result.stdout.strip()}"
+        )


### PR DESCRIPTION
Hi, I was just spinning up this project to see if I could add TD bank statements here in Canada when I realized there was a test failure out-of-the-box. It turns out there's a timezone handling discrepancy that shows up when I run the tests here in Canada with a UTC-negative timezone.

The Rust core parses statement dates into midnight-UTC millisecond timestamps (`DateParts::to_utc_timestamp` in `src/formats/date/mod.rs`) and passes them to Python as raw `i64` values. On the Python side, `Transaction.__init__` converted them back with:

```python
self.date = datetime.fromtimestamp(date / 1000.0).date()
```

`datetime.fromtimestamp()` without a `tz` argument interprets the timestamp in the machine's local timezone. Midnight UTC on 2025-01-01 is 7pm 2024-12-31 in US Eastern, so every date shifts back a day. East-of-UTC machines (e.g. Australia) are unaffected because midnight UTC lands mid-morning the same day — which is why the test suite passes there but `test_parse_generates_correct_csv` and `test_parse_layout_generates_correct_csv` fail for anyone west of Greenwich.

I fixed this by converting to UTC so the round-trip is lossless in every timezone:

```python
self.date = datetime.fromtimestamp(date / 1000.0, tz=timezone.utc).date()
```

I audited the rest of the codebase for other timezone-sensitive conversions, and this was the only one:

- The Rust side is consistently UTC — all 13 date formats funnel through `to_utc_timestamp`, and year-crossover fixing, day grouping, and ordering all operate on explicit `DateTime<Utc>` values or raw i64 comparisons. No `Local`, no `now()`.
- The PyO3 boundary passes plain `i64` (the pyo3 `chrono` feature is not enabled), so no timezone is attached in marshaling.
- `to_csv()` / `to_pandas_dict()` serialize the already-converted `date` object verbatim, so this one-line fix corrects both output paths.
- Dates flow strictly Rust→Python; there is no Python→Rust date path to audit.

I also added `tests/python/test_structs__transaction.py`:

- `test_timestamp_converts_to_utc_date` — a known midnight-UTC timestamp converts to the expected calendar date.
- `test_timestamp_conversion_is_timezone_independent` — runs the conversion in subprocesses with `TZ` pinned to `America/New_York`, `Australia/Sydney`, and `UTC`, asserting the date is identical in all three. This test fails against the old code on any machine (verified: the old code yields 2024-12-31 under `TZ=America/New_York`), so the regression can't silently return regardless of where CI runs.
